### PR TITLE
Fixed issue causing NaN azimuth

### DIFF
--- a/src/SunPosition.h
+++ b/src/SunPosition.h
@@ -62,13 +62,13 @@ struct SunPosition {
         float y = tan(ObliqCor / 2) * tan(ObliqCor / 2);
         float eqTime = 4 * degrees(y * sin(2 * GeomMeanLong) - 2 * EccEart * sin(GeomMeanAnom) + 4 * EccEart * y * sin(GeomMeanAnom) * cos(2 * GeomMeanLong) - 0.5 * y * y * sin(4 * GeomMeanLong) - 1.25 * EccEart * EccEart * sin(2 * GeomMeanAnom));   // Eq of Time (minutes)
 #endif
-        ha = degrees(acos(-0.01454 / (cos(lat) * cos(decl)) - tan(lat) * tan(decl)));       // HA sunrise
-        if (abs(gmt) <= 12) gmt *= 60;                                                      // gmt -> minutes
-        noonT = 720 - 4 * lon - eqTime + gmt;                                               // Solar Noon (min) + gmt
-        float hrAngl = fmod(hours * 1440 + eqTime + 4 * lon, 1440) / 4;                     // True Solar Time (min)
-        hrAngl = hrAngl + (hrAngl < 0 ? 180 : -180);                                        // Hour Angle
-        zen = acos(sin(lat) * sin(decl) + cos(lat) * cos(decl) * cos(radians(hrAngl)));     // Zenith
-        azm = degrees(acos(((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen))));   // Azimuth
+        ha = degrees(acos(-0.01454 / (cos(lat) * cos(decl)) - tan(lat) * tan(decl)));                       // HA sunrise
+        if (abs(gmt) <= 12) gmt *= 60;                                                                      // gmt -> minutes
+        noonT = 720 - 4 * lon - eqTime + gmt;                                                               // Solar Noon (min) + gmt
+        float hrAngl = fmod(hours * 1440 + eqTime + 4 * lon, 1440) / 4;                                     // True Solar Time (min)
+        hrAngl = hrAngl + (hrAngl < 0 ? 180 : -180);                                                        // Hour Angle
+        zen = acos(sin(lat) * sin(decl) + cos(lat) * cos(decl) * cos(radians(hrAngl)));                     // Zenith
+        azm = degrees(acos(max(min(((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen)),-1),1)));    // Azimuth
         decl = degrees(decl);
         alt = 90 - degrees(zen);
         azm = (hrAngl > 0) ? (azm + 180) : (540 - azm);


### PR DESCRIPTION
### Fixed issue causing NaN azimuth when azimuth was close to 0-360 or 180

#### Description:
The issue causing the azimuth to return NaN when it was close to 0-360 or 180 has been fixed.

#### Example of the problem:

**CODE:**
```cpp
#include <SunPosition.h>
#include "Arduino.h"

#define PRECISION 5

unsigned long int t = 1700000000;
float lat = 45;
float lon = 11;

float getSunElevation() {
  SunPosition sun(lat, lon, t);
  return sun.altitude();
}

float getSunAzimuth() {
  SunPosition sun(lat, lon, t);
  return sun.azimuth();
}

void setup() {
  Serial.begin(115200);
  while (!Serial) {}
}

void loop() {
  t++;

  if (isnan(getSunElevation()) || isnan(getSunAzimuth())){
    t--; 
    do{
      Serial.println("Time: " + String(t) + " - Ele: " + String(getSunElevation(), PRECISION) + " - Azi:" + String(getSunAzimuth(), PRECISION));
      t++;
    } while (isnan(getSunElevation()) || isnan(getSunAzimuth()));

    Serial.println("Time: " + String(t) + " - Ele: " + String(getSunElevation(), PRECISION) + " - Azi:" + String(getSunAzimuth(), PRECISION));
    Serial.println();
  }
}
```

**SERIAL OUTPUT:**
```
Time: 1700175624 - Ele: -63.18660 - Azi:359.93439
Time: 1700175625 - Ele: -63.18661 - Azi:    nan
Time: 1700175626 - Ele: -63.18661 - Azi:    nan
Time: 1700175627 - Ele: -63.18661 - Azi:    nan
Time: 1700175628 - Ele: -63.18661 - Azi:    nan
Time: 1700175629 - Ele: -63.18661 - Azi:    nan
Time: 1700175630 - Ele: -63.18661 - Azi:    nan
Time: 1700175631 - Ele: -63.18661 - Azi:    nan
Time: 1700175632 - Ele: -63.18661 - Azi:    nan
Time: 1700175633 - Ele: -63.18660 - Azi:0.06561

Time: 1700218835 - Ele: 26.55935 - Azi:180.00000
Time: 1700218836 - Ele: 26.55936 - Azi:    nan
Time: 1700218837 - Ele: 26.55936 - Azi:    nan
Time: 1700218838 - Ele: 26.55936 - Azi:    nan
Time: 1700218839 - Ele: 26.55936 - Azi:    nan
Time: 1700218840 - Ele: 26.55936 - Azi:    nan
Time: 1700218841 - Ele: 26.55936 - Azi:    nan
Time: 1700218842 - Ele: 26.55935 - Azi:180.00000

Time: 1700262034 - Ele: -63.44598 - Azi:359.94064
Time: 1700262035 - Ele: -63.44599 - Azi:    nan
Time: 1700262036 - Ele: -63.44599 - Azi:    nan
Time: 1700262037 - Ele: -63.44599 - Azi:    nan
Time: 1700262038 - Ele: -63.44599 - Azi:    nan
Time: 1700262039 - Ele: -63.44599 - Azi:    nan
Time: 1700262040 - Ele: -63.44599 - Azi:    nan
Time: 1700262041 - Ele: -63.44599 - Azi:    nan
Time: 1700262042 - Ele: -63.44599 - Azi:    nan
Time: 1700262043 - Ele: -63.44598 - Azi:0.05936

......
```

---

#### How the issue was fixed:
The issue was in the following line of code:
```cpp
azm = degrees(acos(((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen)))); // Azimuth
```
The `acos()` function accepts values only in the range of -1 to 1. Due to floating-point rounding errors, the expression `((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen))` could result in values slightly outside this range, which causes the `acos()` function to return NaN.

For example, in some cases, the calculation produced values slightly greater than 1 or slightly less than -1:
```
Unix:1700175628   Lat:45   Lon:11   <((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen))>:-1.0000001192
Unix:1700218838   Lat:45   Lon:11   <((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen))>:1.0000001192
```

**Solution:**
To address this issue, the calculation has been modified to clamp the result between -1 and 1 before passing it to `acos()`. This ensures that the value remains within the valid range for `acos()` and prevents it from returning NaN:
```cpp
azm = degrees(acos(max(min(((sin(lat) * cos(zen)) - sin(decl)) / (cos(lat) * sin(zen)),-1),1))); // Azimuth
```
This adjustment prevents the expression from exceeding the allowable range for `acos()`, thereby eliminating the errors and returning valid azimuth values.

---